### PR TITLE
Initial commit of minimal working functionality

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -18,6 +18,9 @@ RUN \
   mkdir -p /opt/mirthconnect/appdata
 WORKDIR /opt/mirthconnect
 
+# Install nc (in order to determine when Mirth Connect is listening)
+RUN apt-get update && apt-get install netcat -y
+
 COPY templates/conf/mirth.properties /opt/mirthconnect/conf/mirth.properties
 
 # NGiNX (X-Forwarded-Proto Proxy)

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,35 @@
+# See https://github.com/brandonstevens/mirth-connect-docker
+FROM java
+
+ENV MIRTHCONNECT_VERSION 3.5.0.8232.b2153
+
+# Install NGiNX
+RUN apt-get update && apt-get install nginx -y --no-install-recommends
+RUN rm -f /etc/nginx/sites-enabled/default
+
+# Install Mirth Connect
+RUN \
+  cd /tmp && \
+  wget http://downloads.mirthcorp.com/connect/$MIRTHCONNECT_VERSION/mirthconnect-$MIRTHCONNECT_VERSION-unix.tar.gz && \
+  tar xvzf mirthconnect-$MIRTHCONNECT_VERSION-unix.tar.gz && \
+  rm -f mirthconnect-$MIRTHCONNECT_VERSION-unix.tar.gz && \
+  mkdir -p /opt/mirthconnect && \
+  mv Mirth\ Connect/* /opt/mirthconnect/ && \
+  mkdir -p /opt/mirthconnect/appdata
+WORKDIR /opt/mirthconnect
+
+COPY templates/conf/mirth.properties /opt/mirthconnect/conf/mirth.properties
+
+# NGiNX (X-Forwarded-Proto Proxy)
+EXPOSE 3000
+
+# Mirth (Direct)
+EXPOSE 80 443
+
+# 10 unmapped channels
+EXPOSE 9661-9670
+
+COPY templates/etc /etc
+COPY templates/bin /usr/local/bin
+
+CMD /usr/local/bin/mirthconnect-wrapper.sh

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,16 +1,18 @@
 # See https://github.com/brandonstevens/mirth-connect-docker
-FROM java
+FROM java:8
 
 ENV MIRTHCONNECT_VERSION 3.5.0.8232.b2153
+ENV MIRTHCONNECT_SHA1SUM 0550d00905ea7161a47d78cedbae35699a5f1b67
 
 # Install NGiNX
-RUN apt-get update && apt-get install nginx -y --no-install-recommends
+RUN apt-get update && apt-get install -y --no-install-recommends nginx && \
+  rm -rf /var/lib/apt/lists/*
 RUN rm -f /etc/nginx/sites-enabled/default
 
 # Install Mirth Connect
-RUN \
-  cd /tmp && \
-  wget http://downloads.mirthcorp.com/connect/$MIRTHCONNECT_VERSION/mirthconnect-$MIRTHCONNECT_VERSION-unix.tar.gz && \
+RUN cd /tmp && \
+  wget https://s3.amazonaws.com/downloads.mirthcorp.com/connect/$MIRTHCONNECT_VERSION/mirthconnect-$MIRTHCONNECT_VERSION-unix.tar.gz && \
+  echo "$MIRTHCONNECT_SHA1SUM" mirthconnect-$MIRTHCONNECT_VERSION-unix.tar.gz | sha1sum -c && \
   tar xvzf mirthconnect-$MIRTHCONNECT_VERSION-unix.tar.gz && \
   rm -f mirthconnect-$MIRTHCONNECT_VERSION-unix.tar.gz && \
   mkdir -p /opt/mirthconnect && \
@@ -19,7 +21,8 @@ RUN \
 WORKDIR /opt/mirthconnect
 
 # Install nc (in order to determine when Mirth Connect is listening)
-RUN apt-get update && apt-get install netcat -y
+RUN apt-get update && apt-get install -y netcat && \
+  rm -rf /var/lib/apt/lists/*
 
 COPY templates/conf/mirth.properties /opt/mirthconnect/conf/mirth.properties
 
@@ -35,4 +38,4 @@ EXPOSE 9661-9670
 COPY templates/etc /etc
 COPY templates/bin /usr/local/bin
 
-CMD /usr/local/bin/mirthconnect-wrapper.sh
+CMD ["/usr/local/bin/mirthconnect-wrapper.sh"]

--- a/LICENSE.md
+++ b/LICENSE.md
@@ -1,0 +1,22 @@
+Copyright (c) 2013 Aptible, Inc.
+
+MIT License
+
+Permission is hereby granted, free of charge, to any person obtaining
+a copy of this software and associated documentation files (the
+"Software"), to deal in the Software without restriction, including
+without limitation the rights to use, copy, modify, merge, publish,
+distribute, sublicense, and/or sell copies of the Software, and to
+permit persons to whom the Software is furnished to do so, subject to
+the following conditions:
+
+The above copyright notice and this permission notice shall be
+included in all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE
+LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
+WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.

--- a/LICENSE.md
+++ b/LICENSE.md
@@ -1,4 +1,4 @@
-Copyright (c) 2013 Aptible, Inc.
+Copyright (c) 2017 Aptible, Inc.
 
 MIT License
 

--- a/Procfile
+++ b/Procfile
@@ -1,0 +1,1 @@
+web: /usr/local/bin/mirthconnect-wrapper.sh

--- a/Procfile
+++ b/Procfile
@@ -1,1 +1,0 @@
-web: /usr/local/bin/mirthconnect-wrapper.sh

--- a/README.md
+++ b/README.md
@@ -1,0 +1,25 @@
+# ![](https://gravatar.com/avatar/11d3bc4c3163e3d238d558d5c9d98efe?s=64) aptible/docker-mirthconnect
+
+A Dockerized installer for the open-source [Mirth Connect](https://www.nextgen.com/Interoperability/Mirth-Solutions/Connect-Overview?tab=true) HL7 application, designed for easy setup on Aptible,
+
+## Deployment
+
+To deploy:
+
+1. From the Aptible Dashboard or Aptible Toolbelt, create a new app in which to deploy. For example:
+
+        aptible apps:create --environment my-environment mirthconnect
+
+2. Deploy the latest version of this app via `aptible deploy`. For example:
+
+        aptible deploy --app mirthconnect --docker-image quay.io/aptible/mirthconnect
+
+By default, this Mirth Connect application will use an in-container Derby database, which **will be destroyed every time the app is restarted or re-deployed.** For this reason, we strongly recommend that you configure your app to use a dedicated PostgreSQL database instead. To do so, create a new PostgreSQL database (from the Aptible Dashboard or using `aptible db:create`), then set this database's URL as the `$DATABASE_URL` for your app. For example:
+
+        aptible config:set --app mirthconnect DATABASE_URL=...
+
+## Copyright and License
+
+MIT License, see [LICENSE](LICENSE.md) for details.
+
+Copyright (c) 2017 [Aptible](https://www.aptible.com) and contributors.

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # ![](https://gravatar.com/avatar/11d3bc4c3163e3d238d558d5c9d98efe?s=64) aptible/docker-mirthconnect
 
-A Dockerized installer for the open-source [Mirth Connect](https://www.nextgen.com/Interoperability/Mirth-Solutions/Connect-Overview?tab=true) HL7 application, designed for easy setup on Aptible,
+A Dockerized installer for the open-source [Mirth Connect](https://www.nextgen.com/Interoperability/Mirth-Solutions/Connect-Overview?tab=true) HL7 application, designed for easy setup on Aptible.
 
 ## Deployment
 
@@ -10,13 +10,26 @@ To deploy:
 
         aptible apps:create --environment my-environment mirthconnect
 
-2. Deploy the latest version of this app via `aptible deploy`. For example:
+1. Deploy the latest version of this app via `aptible deploy`. For example:
 
         aptible deploy --app mirthconnect --docker-image quay.io/aptible/mirthconnect
 
-By default, this Mirth Connect application will use an in-container Derby database, which **will be destroyed every time the app is restarted or re-deployed.** For this reason, we strongly recommend that you configure your app to use a dedicated PostgreSQL database instead. To do so, create a new PostgreSQL database (from the Aptible Dashboard or using `aptible db:create`), then set this database's URL as the `$DATABASE_URL` for your app. For example:
+1. _(Optional, but recommended.)_ By default, this Mirth Connect application will use an in-container Derby database, which **will be destroyed every time the app is restarted or re-deployed.** For this reason, we strongly recommend that you configure your app to use a dedicated PostgreSQL database instead. To do so, create a new PostgreSQL database (from the Aptible Dashboard or using `aptible db:create`), then set this database's URL as the `$DATABASE_URL` for your app. For example:
 
         aptible config:set --app mirthconnect DATABASE_URL=...
+
+1. _(Optional, but recommended.)_ By default, Mirth Connect will be set up with its administrator username and password both set to "admin". For production deployments, we strongly recommend resetting this password **before** creating an HTTPS Endpoint and opening up the Mirth Connect Administrator to the public internet. To reset the password, you can run `aptible ssh` and launch the Mirth CLI:
+
+        aptible ssh --app mirthconnect mirthconnect-wrapper.sh --cli -u admin -p admin
+
+    At this prompt, you can change the admin password like so:
+
+        $ user changepw admin newpassword
+
+
+1. Finally, create an HTTPS Endpoint from the Aptible Dashboard, tied to port 3000. (If you don't select a port when you create the Endpoint, it will default to 3000.) Once the Endpoint is provisioned, you'll be able to access the Mirth Connect Administrator at the address displayed on the Aptible Dashboard. From there, you can click "Launch Mirth Connect Administrator" to download the JAR file from which you'll set up channels.
+
+1. This default image is configured to EXPOSE 10 TCP HL7 channels, on ports 9661 through 9670. To receive HL7 messages on Aptible, you'll need to set up a site-to-site IPsec VPN connection with the data partner who'll be sending the HL7 messages. When you're ready to set up this VPN connection, just [reach out](http://contact.aptible.com) to Aptible Support!
 
 ## Copyright and License
 

--- a/templates/bin/mirthconnect-wrapper.sh
+++ b/templates/bin/mirthconnect-wrapper.sh
@@ -1,0 +1,29 @@
+#!/bin/bash
+set -o errexit
+set -o pipefail
+
+# For URL parsing...
+. /usr/local/bin/utilities.sh
+PROPERTIES_FILE=/opt/mirthconnect/conf/mirth.properties
+
+# Start NGiNX reverse proxy
+/usr/sbin/nginx
+
+# If DATABASE_URL is defined (and is a postgresql:// URL), replace the
+# default in-container Derby database connection with a PostgreSQL connection
+if [ -n "$DATABASE_URL" ]; then
+  parse_url "$DATABASE_URL"
+
+  if [ "$protocol" != "postgresql://" ]; then
+    echo "ERROR: DATABASE_URL must be a postgresql:// URL"
+    exit 1
+  fi
+
+  sed -i "s/^database =.*/database = postgres/" $PROPERTIES_FILE
+  sed -i "s/^database.url =.*/database.url = jdbc:postgresql:\/\/${host_and_port}\/${database}\?ssl=true\&sslfactory=org.postgresql.ssl.NonValidatingFactory/" $PROPERTIES_FILE
+  sed -i "s/^database.username =/database.username = ${user}/" $PROPERTIES_FILE
+  sed -i "s/^database.password =/database.password = ${password}/" $PROPERTIES_FILE
+fi
+
+# Launch Mirth Server
+java -jar mirth-server-launcher.jar

--- a/templates/bin/mirthconnect-wrapper.sh
+++ b/templates/bin/mirthconnect-wrapper.sh
@@ -2,34 +2,76 @@
 set -o errexit
 set -o pipefail
 
+# Usage:
+# mirthconnect-wrapper.sh [--configure | --cli]
+#   With no arguments/flags, configures mirth.properties (e.g. setting database
+#   properties based on $DATABASE_URL), then launches Mirth Administrator and
+#   an NGiNX reverse proxy. With --configure, only configures mirth.properties.
+#   With --cli, launches Mirth Administrator in the background and then runs
+#   mirth-cli-launcher.jar (optionally )
+
 # For URL parsing...
 . /usr/local/bin/utilities.sh
 PROPERTIES_FILE=/opt/mirthconnect/conf/mirth.properties
 
-# If DATABASE_URL is defined (and is a postgresql:// URL), replace the
-# default in-container Derby database connection with a PostgreSQL connection
-if [ -n "$DATABASE_URL" ]; then
-  parse_url "$DATABASE_URL"
+function setup_mirth_properties() {
+  # If DATABASE_URL is defined (and is a postgresql:// URL), replace the
+  # default in-container Derby database connection with a PostgreSQL connection
+  if [ -n "$DATABASE_URL" ]; then
+    parse_url "$DATABASE_URL"
 
-  if [ "$protocol" != "postgresql://" ]; then
-    echo "ERROR: DATABASE_URL must be a postgresql:// URL"
-    exit 1
+    if [ "$protocol" != "postgresql://" ]; then
+      echo "ERROR: DATABASE_URL must be a postgresql:// URL"
+      exit 1
+    fi
+
+    sed -i "s%^database =.*%database = postgres%" $PROPERTIES_FILE
+    sed -i "s%^database.url =.*%database.url = jdbc:postgresql://${host_and_port}/${database}\?ssl=true\&sslfactory=org.postgresql.ssl.NonValidatingFactory%" $PROPERTIES_FILE
+    sed -i "s%^database.username =.*%database.username = ${user}%" $PROPERTIES_FILE
+    sed -i "s%^database.password =.*%database.password = ${password}%" $PROPERTIES_FILE
+  fi
+}
+
+function wait_for_mirth() {
+  echo "INFO Waiting for Mirth Connect to start up..."
+  while ! echo exit | nc localhost 443 &> /dev/null; do echo -n .; sleep 1; done
+  echo
+}
+
+function wait_and_start_nginx() {
+  wait_for_mirth
+
+  echo "INFO Launching NGiNX..."
+  /usr/sbin/nginx
+}
+
+# All functions depend on updating mirth.properties
+setup_mirth_properties
+
+if [[ "$1" == "--configure" ]]; then
+  exit 0
+
+elif [[ "$1" == "--cli" ]]; then
+  shift
+
+  # Launch Mirth Server (required for CLI access)
+  echo "INFO Launching Mirth Connect Administrator..."
+  if ! echo exit | nc localhost 443 &> /dev/null; then
+    java -jar mirth-server-launcher.jar &> /dev/null &
   fi
 
-  sed -i "s/^database =.*/database = postgres/" $PROPERTIES_FILE
-  sed -i "s/^database.url =.*/database.url = jdbc:postgresql:\/\/${host_and_port}\/${database}\?ssl=true\&sslfactory=org.postgresql.ssl.NonValidatingFactory/" $PROPERTIES_FILE
-  sed -i "s/^database.username =/database.username = ${user}/" $PROPERTIES_FILE
-  sed -i "s/^database.password =/database.password = ${password}/" $PROPERTIES_FILE
+  wait_for_mirth
+  java -jar mirth-cli-launcher.jar -a https://127.0.0.1:443 -v 0.0.0 "$@"
+
+elif [[ "$#" -eq 0 ]]; then
+  # Start NGiNX reverse proxy
+  wait_and_start_nginx &
+
+  # Launch Mirth Server
+  echo "INFO Launching Mirth Connect Administrator..."
+  exec java -jar mirth-server-launcher.jar
+
+else
+  echo "Unrecognized command: $1"
+  exit 1
 fi
-
-# Launch Mirth Server
-echo "INFO: Launching Mirth Connect Administrator..."
-java -jar mirth-server-launcher.jar &
-
-echo "INFO: Waiting for Mirth Connect to start up..."
-while ! echo exit | nc localhost 443 &> /dev/null; do echo -n .; sleep 1; done
-echo
-
-# Start NGiNX reverse proxy
-echo "INFO: Launching NGiNX..."
-/usr/sbin/nginx

--- a/templates/bin/mirthconnect-wrapper.sh
+++ b/templates/bin/mirthconnect-wrapper.sh
@@ -6,9 +6,6 @@ set -o pipefail
 . /usr/local/bin/utilities.sh
 PROPERTIES_FILE=/opt/mirthconnect/conf/mirth.properties
 
-# Start NGiNX reverse proxy
-/usr/sbin/nginx
-
 # If DATABASE_URL is defined (and is a postgresql:// URL), replace the
 # default in-container Derby database connection with a PostgreSQL connection
 if [ -n "$DATABASE_URL" ]; then
@@ -26,4 +23,13 @@ if [ -n "$DATABASE_URL" ]; then
 fi
 
 # Launch Mirth Server
-java -jar mirth-server-launcher.jar
+echo "INFO: Launching Mirth Connect Administrator..."
+java -jar mirth-server-launcher.jar &
+
+echo "INFO: Waiting for Mirth Connect to start up..."
+while ! echo exit | nc localhost 443 &> /dev/null; do echo -n .; sleep 1; done
+echo
+
+# Start NGiNX reverse proxy
+echo "INFO: Launching NGiNX..."
+/usr/sbin/nginx

--- a/templates/bin/utilities.sh
+++ b/templates/bin/utilities.sh
@@ -1,0 +1,28 @@
+#!/bin/bash
+
+parse_url()
+{
+  # cf http://stackoverflow.com/a/17287984
+  protocol="$(echo "$1" | grep :// | sed -e's,^\(.*://\).*,\1,g')"
+  # remove the protocol
+  url=$(echo $1 | sed -e s,$protocol,,g)
+  # extract the user and password (if any)
+  user_and_password="$(echo $url | grep @ | cut -d@ -f1)"
+  password="$(echo $user_and_password | grep : | cut -d: -f2)"
+  if [ -n "$password" ]; then
+    user="$(echo $user_and_password | grep : | cut -d: -f1)"
+  else
+    user="$user_and_password"
+  fi
+
+  # extract the host
+  host_and_port="$(echo $url | sed -e s,$user_and_password@,,g | cut -d/ -f1)"
+  port="$(echo $host_and_port | grep : | cut -d: -f2)"
+  if [ -n "$port" ]; then
+    host="$(echo $host_and_port | grep : | cut -d: -f1)"
+  else
+    host="$host_and_port"
+  fi
+
+  database="$(echo $url | grep / | cut -d/ -f2-)"
+}

--- a/templates/conf/mirth.properties
+++ b/templates/conf/mirth.properties
@@ -1,0 +1,18 @@
+http.contextpath = /
+http.host = 0.0.0.0
+https.host = 0.0.0.0
+http.port = 80
+https.port = 443
+
+database = derby
+database.url = jdbc:derby:${dir.appdata}/mirthdb;create=true
+database.username =
+database.password =
+
+dir.appdata = appdata
+dir.tempdata = ${dir.appdata}/temp
+
+keystore.path = ${dir.appdata}/keystore.jks
+keystore.storepass = 81uWxplDtB
+keystore.keypass = 81uWxplDtB
+keystore.type = JCEKS

--- a/templates/etc/nginx/nginx.conf
+++ b/templates/etc/nginx/nginx.conf
@@ -28,12 +28,6 @@ http {
   gzip on;
   gzip_disable "msie6";
 
-  # http://serverfault.com/a/637849
-  # Enable PFS for most browsers, and provide SSLv3 while mitigating POODLE
-  ssl_ciphers EECDH+ECDSA+AESGCM:EECDH+aRSA+AESGCM:EECDH+ECDSA+SHA384:EECDH+ECDSA+SHA256:EECDH+aRSA+SHA384:EECDH+aRSA+SHA256:EECDH+aRSA+RC4:EECDH:EDH+aRSA:RC4:!aNULL:!eNULL:!LOW:!3DES:!MD5:!EXP:!PSK:!SRP:!DSS:!CAMELLIA;
-  ssl_protocols SSLv3 TLSv1 TLSv1.1 TLSv1.2;
-  ssl_prefer_server_ciphers on;
-
   # X-Forwarded-Proto -intelligent proxy for Mirth Connect
   upstream mirth_http {
     server localhost:80;

--- a/templates/etc/nginx/nginx.conf
+++ b/templates/etc/nginx/nginx.conf
@@ -1,6 +1,7 @@
 user www-data;
 worker_processes 4;
 pid /run/nginx.pid;
+daemon off;
 
 events {
   worker_connections 768;

--- a/templates/etc/nginx/nginx.conf
+++ b/templates/etc/nginx/nginx.conf
@@ -1,0 +1,68 @@
+user www-data;
+worker_processes 4;
+pid /run/nginx.pid;
+
+events {
+  worker_connections 768;
+}
+
+http {
+  sendfile on;
+  tcp_nopush on;
+  tcp_nodelay on;
+  keepalive_timeout 65;
+  types_hash_max_size 2048;
+  client_max_body_size 0;
+
+  # http://stackoverflow.com/a/3710649
+  proxy_buffers 8 16k;
+  proxy_buffer_size 32k;
+
+  include /etc/nginx/mime.types;
+  default_type application/octet-stream;
+
+  access_log /dev/stdout;
+  error_log /dev/stdout;
+
+  gzip on;
+  gzip_disable "msie6";
+
+  # http://serverfault.com/a/637849
+  # Enable PFS for most browsers, and provide SSLv3 while mitigating POODLE
+  ssl_ciphers EECDH+ECDSA+AESGCM:EECDH+aRSA+AESGCM:EECDH+ECDSA+SHA384:EECDH+ECDSA+SHA256:EECDH+aRSA+SHA384:EECDH+aRSA+SHA256:EECDH+aRSA+RC4:EECDH:EDH+aRSA:RC4:!aNULL:!eNULL:!LOW:!3DES:!MD5:!EXP:!PSK:!SRP:!DSS:!CAMELLIA;
+  ssl_protocols SSLv3 TLSv1 TLSv1.1 TLSv1.2;
+  ssl_prefer_server_ciphers on;
+
+  # X-Forwarded-Proto -intelligent proxy for Mirth Connect
+  upstream mirth_http {
+    server localhost:80;
+  }
+
+  upstream mirth_https {
+    server localhost:443;
+  }
+
+  server {
+    listen 3000;
+    keepalive_timeout 5;
+
+    location / {
+      proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+      proxy_set_header Host $http_host;
+      proxy_redirect off;
+
+      if ($http_x_forwarded_proto != 'https') {
+        proxy_pass http://mirth_http;
+      }
+      if ($http_x_forwarded_proto = 'https') {
+        proxy_pass https://mirth_https;
+      }
+
+      proxy_http_version 1.1;
+      proxy_set_header Upgrade $http_upgrade;
+      proxy_set_header Connection "upgrade";
+
+      break;
+    }
+  }
+}


### PR DESCRIPTION
A container launched from this built image will: 

* Run the Mirth Connect Administrator, listening for HTTP/HTTPS traffic on the default ports 80 and 443, respectively 
* Run a NGiNX server on port 3000 which proxies requests to Mirth Connect, forwaring to port 443 if it receives `X-Forwarded-Proto: https`

In this way, the image supports being run directly, or behind a sequence of reverse proxies (as is the case with Aptible Enclave Endpoints). Note that since Mirth Connect is listening internally on ports 80/443, the user- facing reverse proxy must also listen on ports 80/443, since Mirth Connect will insist on rewriting all URLs to include the ports it believes itself to be listening on. :sideeye:

By default, this image will use an in-container Derby database for storage of message data and configuration. It also supports using a PostgreSQL database, if a valid database URL is present in `$DATABASE_URL`.

cc: @UserNotFound @krallin 

There are a few more changes I'd like to make, for usability, but please let me know if you see anything totally off here.